### PR TITLE
Develop

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    worldApi('com.sentiance:sdk:4.1.16-R@aar') {transitive = true}
-    chinaApi('com.sentiance:sdk:4.1.16-R@aar') {transitive = true}
+    worldApi('com.sentiance:sdk:4.1.20-R@aar') {transitive = true}
+    chinaApi('com.sentiance:sdk:4.1.20-R@aar') {transitive = true}
 }

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -92,7 +92,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
             public void onStartFinished(SdkStatus sdkStatus) {
               Log.v(LOG_TAG, "SDK started successfully");
               if (promise != null) {
-                promise.resolve(null);
+                promise.resolve(convertSdkStatus(sdkStatus));
               }
             }
           });

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -40,7 +40,7 @@
         NSLog(@"SDK started properly.");
       } else if ([status startStatus] == SENTStartStatusPending) {
         NSLog(@"Something prevented the SDK to start properly. Once fixed, the SDK will start automatically.");
-      } else {
+      } else {
         NSLog(@"SDK did not start.");
       }
     }];
@@ -111,13 +111,13 @@ RCT_EXPORT_METHOD(start:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseReje
   @try {
     [[SENTSDK sharedInstance] start:^(SENTSDKStatus* status) {
       if ([status startStatus] == SENTStartStatusStarted) {
-        // SDK started properly.
-        resolve(@"STARTED");
+        NSLog(@"SDK started properly.");
+        resolve([self convertSdkStatusToDict:status]);
       } else if ([status startStatus] == SENTStartStatusPending) {
-        // Something prevented the SDK to start properly. Once fixed, the SDK will start automatically.
-        resolve(@"PENDING");
+        NSLog(@"Something prevented the SDK to start properly. Once fixed, the SDK will start automatically.");
+        resolve([self convertSdkStatusToDict:status]);
       } else {
-        // SDK did not start.
+        NSLog(@"SDK did not start.");
         reject(@"", @"SDK did not start.", nil);
       }
     }];


### PR DESCRIPTION
Starting the SDK does not trigger SDK status update handler anymore since new SDK. Resolve start method with SDK status (this is the same behaviour as when using the native SDK).