### PR TITLE
Revert "Update Android China SDK to 4.2.9-CN"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     worldApi('com.sentiance:sdk:4.4.0-R@aar') {transitive = true}
-    chinaApi('com.sentiance:sdk-cn:4.2.9-CN@aar') {
+    chinaApi('com.sentiance:sdk-cn:4.2.8-CN@aar') {
         exclude group: 'com.android.support'
         transitive = true
     }


### PR DESCRIPTION
Sorry guys. Seems like 4.2.9-CN was an experimental build. Reverting back to 4.2.8-CN (which is not in our public repo).