### PR TITLE
Feature/android sdk 4.6.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    worldApi('com.sentiance:sdk:4.5.2-R@aar') {transitive = true}
+    worldApi('com.sentiance:sdk:4.6.0-R@aar') {transitive = true}
     chinaApi('com.sentiance:sdk-cn:4.2.8-CN@aar') {
         exclude group: 'com.android.support'
         transitive = true

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceConfig.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceConfig.java
@@ -10,6 +10,7 @@ public class RNSentianceConfig {
   public String appSecret;
   public Boolean autoStart = true;
   public Notification notification = null;
+  public String baseURL = null;
   public OnInitCallback initCallback = new OnInitCallback() {
     @Override
     public void onInitSuccess() {
@@ -36,5 +37,9 @@ public class RNSentianceConfig {
 
   public void setAutoStart(Boolean autoStart) {
     this.autoStart = autoStart;
+  }
+
+  public void setBaseURL(String url) {
+    this.baseURL = url;
   }
 }

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -95,10 +95,14 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
 
     Notification sdkNotification = sentianceConfig.notification != null ? sentianceConfig.notification
             : createNotification();
-    SdkConfig config = new SdkConfig.Builder(sentianceConfig.appId, sentianceConfig.appSecret, sdkNotification)
+    SdkConfig.Builder configBuilder = new SdkConfig.Builder(sentianceConfig.appId, sentianceConfig.appSecret, sdkNotification)
             .setOnSdkStatusUpdateHandler(statusHandler)
-            .setMetaUserLinker(metaUserLinker)
-            .build();
+            .setMetaUserLinker(metaUserLinker);
+
+    if (sentianceConfig.baseURL != null) {
+      configBuilder.baseURL(sentianceConfig.baseURL);
+    }
+    SdkConfig config = configBuilder.build();
 
     OnInitCallback initCallback = new OnInitCallback() {
       @Override


### PR DESCRIPTION
v4.6.0 support setting the API URL via the [SdkConfig.Builder](https://betadoc.sentiance.com/sdk/api-reference/android/sdkconfig/sdkconfig-builder#baseurl). I've made some modifications here to pass that URL to the SDK, but I've left the part where/how we expose this to the enclosing app.