### PR TITLE
subscriptions fix

### DIFF
--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -287,7 +287,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
       this.reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(key, map);
     } else {
       //add delay
-      final Counter retry = new Counter(3);
+      final Counter retry = new Counter(20);
       mHandler.postDelayed(new Runnable() {
         @Override
         public void run() {

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -28,6 +28,7 @@ import com.sentiance.sdk.trip.TransportMode;
 
 import android.content.pm.PackageManager;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -59,7 +60,29 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   private final String E_SDK_DISABLE_BATTERY_OPTIMIZATION = "E_SDK_DISABLE_BATTERY_OPTIMIZATION";
   private final CountDownLatch metaUserLinkLatch = new CountDownLatch(1);
   private Boolean metaUserLinkResult = false;
-  private OnStartFinishedHandler mHandler;
+  private final Handler mHandler = new Handler(Looper.getMainLooper());
+
+  // Create SDK status update handler which sends event to JS
+  private OnSdkStatusUpdateHandler sdkStatusUpdateHandler = new OnSdkStatusUpdateHandler() {
+    @Override
+    public void onSdkStatusUpdate(SdkStatus status) {
+      sendStatusUpdate(status);
+    }
+  };
+
+  // Create metaUserLinker which sends event to JS and waits for result via @ReactMethod metaUserLinkCallback
+  private MetaUserLinker metaUserLinker = new MetaUserLinker() {
+    @Override
+    public boolean link(String installId) {
+      sendMetaUserLink(installId);
+      try {
+        metaUserLinkLatch.await();
+        return metaUserLinkResult;
+      } catch (InterruptedException e) {
+        return false;
+      }
+    }
+  };
 
   public RNSentianceModule(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -71,43 +94,11 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
     sentianceConfig = config;
   }
 
-  private static OnStartFinishedHandler startFinishedHandler(final Promise promise) {
-    OnStartFinishedHandler handler = new OnStartFinishedHandler() {
-      @Override
-      public void onStartFinished(SdkStatus sdkStatus) {
-        promise.resolve(convertSdkStatus(sdkStatus));
-      }
-    };
-
-    return handler;
-  }
-
   private void initializeSentianceSdk(final Promise promise) {
-    // Create the config.
-    OnSdkStatusUpdateHandler statusHandler = new OnSdkStatusUpdateHandler() {
-      @Override
-      public void onSdkStatusUpdate(SdkStatus status) {
-        sendStatusUpdate(status);
-      }
-    };
-    // Create metaUserLinker wich sends event to JS and waits for result via @ReactMethod metaUserLinkCallback
-    MetaUserLinker metaUserLinker = new MetaUserLinker() {
-      @Override
-      public boolean link(String installId) {
-        sendMetaUserLink(installId);
-        try {
-          metaUserLinkLatch.await();
-          return metaUserLinkResult;
-        } catch(InterruptedException e) {
-          return false;
-        }
-      }
-    };
-
     Notification sdkNotification = sentianceConfig.notification != null ? sentianceConfig.notification
             : createNotification();
     SdkConfig.Builder configBuilder = new SdkConfig.Builder(sentianceConfig.appId, sentianceConfig.appSecret, sdkNotification)
-            .setOnSdkStatusUpdateHandler(statusHandler)
+            .setOnSdkStatusUpdateHandler(sdkStatusUpdateHandler)
             .setMetaUserLinker(metaUserLinker);
 
     if (sentianceConfig.baseURL != null) {
@@ -284,23 +275,44 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   }
 
   private void sendStatusUpdate(SdkStatus sdkStatus) {
-    this.reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(STATUS_UPDATE,
-            convertSdkStatus(sdkStatus));
+    sendEvent(STATUS_UPDATE, convertSdkStatus(sdkStatus));
   }
 
   private void sendMetaUserLink(String installId) {
-    this.reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(META_USER_LINK,
-            convertInstallId(installId));
+    sendEvent(META_USER_LINK, convertInstallId(installId));
+  }
+
+  private void sendEvent(final String key, final WritableMap map) {
+    if (reactContext.hasActiveCatalystInstance()) {
+      this.reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(key, map);
+    } else {
+      //add delay
+      final Counter retry = new Counter(3);
+      mHandler.postDelayed(new Runnable() {
+        @Override
+        public void run() {
+          if (RNSentianceModule.this.reactContext.hasActiveCatalystInstance()) {
+            RNSentianceModule.this.reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(key, map);
+          } else if (retry.count-- > 0) {
+            mHandler.postDelayed(this, 500);
+          }
+        }
+      }, 500);
+    }
   }
 
   @ReactMethod
   public void start(final Promise promise) {
-    mHandler = startFinishedHandler(promise);
-
-    new Handler(Looper.getMainLooper()).post(new Runnable() {
+    mHandler.post(new Runnable() {
       @Override
       public void run() {
-        Sentiance.getInstance(getReactApplicationContext()).start(mHandler);
+        Sentiance.getInstance(getReactApplicationContext()).start(new OnStartFinishedHandler() {
+          @Override
+          public void onStartFinished(SdkStatus sdkStatus) {
+            sendStatusUpdate(sdkStatus);
+            promise.resolve(convertSdkStatus(sdkStatus));
+          }
+        });
       }
     });
   }
@@ -492,5 +504,21 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   public void onHostDestroy() {
     // Activity `onDestroy`
   }
+
+  OnSdkStatusUpdateHandler getSdkStatusUpdateHandler() {
+    return sdkStatusUpdateHandler;
+  }
+
+  MetaUserLinker getMetaUserLinker() {
+    return metaUserLinker;
+  }
+
+  private class Counter {
+    Counter(int count) {
+      this.count = count;
+    }
+    int count;
+  }
+
 
 }

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -1,6 +1,5 @@
 package com.sentiance.react.bridge;
 
-import com.sentiance.react.bridge.RNSentianceConfig;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -28,7 +27,6 @@ import com.sentiance.sdk.trip.TransportMode;
 
 import android.content.pm.PackageManager;
 import android.os.Handler;
-import android.os.HandlerThread;
 import android.os.Looper;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -61,6 +59,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   private final CountDownLatch metaUserLinkLatch = new CountDownLatch(1);
   private Boolean metaUserLinkResult = false;
   private final Handler mHandler = new Handler(Looper.getMainLooper());
+  private boolean metaUserLinkingEnabled = false;
 
   // Create SDK status update handler which sends event to JS
   private OnSdkStatusUpdateHandler sdkStatusUpdateHandler = new OnSdkStatusUpdateHandler() {
@@ -98,8 +97,9 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
     Notification sdkNotification = sentianceConfig.notification != null ? sentianceConfig.notification
             : createNotification();
     SdkConfig.Builder configBuilder = new SdkConfig.Builder(sentianceConfig.appId, sentianceConfig.appSecret, sdkNotification)
-            .setOnSdkStatusUpdateHandler(sdkStatusUpdateHandler)
-            .setMetaUserLinker(metaUserLinker);
+            .setOnSdkStatusUpdateHandler(sdkStatusUpdateHandler);
+    if(metaUserLinkingEnabled)
+      configBuilder.setMetaUserLinker(metaUserLinker);
 
     if (sentianceConfig.baseURL != null) {
       configBuilder.baseURL(sentianceConfig.baseURL);
@@ -261,6 +261,13 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   @ReactMethod
   public void init(final String appId, final String appSecret, final Promise promise) {
     Log.v(LOG_TAG, "Initializing SDK with APP_ID: " + appId + " and SECRET: " + appSecret);
+    init(appId,appSecret,false,promise);
+  }
+
+  @ReactMethod
+  public void init(final String appId, final String appSecret,boolean metaUserLinkingEnabled, final Promise promise) {
+    Log.v(LOG_TAG, "Initializing SDK with APP_ID: " + appId + " and SECRET: " + appSecret);
+    this.metaUserLinkingEnabled = metaUserLinkingEnabled;
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
       public void run() {

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -260,13 +260,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
 
   @ReactMethod
   public void init(final String appId, final String appSecret, final Promise promise) {
-    Log.v(LOG_TAG, "Initializing SDK with APP_ID: " + appId + " and SECRET: " + appSecret);
-    init(appId,appSecret,false,promise);
-  }
-
-  @ReactMethod
-  public void init(final String appId, final String appSecret,boolean metaUserLinkingEnabled, final Promise promise) {
-    Log.v(LOG_TAG, "Initializing SDK with APP_ID: " + appId + " and SECRET: " + appSecret);
+    Log.v(LOG_TAG, "Initializing SDK with APP_ID: " + appId);
     this.metaUserLinkingEnabled = metaUserLinkingEnabled;
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
@@ -279,6 +273,12 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
         }
       }
     });
+  }
+
+  @ReactMethod
+  public void initWithUserLinkingEnabled(final String appId, final String appSecret, final Promise promise) {
+    this.metaUserLinkingEnabled = true;
+    init(appId,appSecret,promise);
   }
 
   private void sendStatusUpdate(SdkStatus sdkStatus) {

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -261,7 +261,6 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   @ReactMethod
   public void init(final String appId, final String appSecret, final Promise promise) {
     Log.v(LOG_TAG, "Initializing SDK with APP_ID: " + appId);
-    this.metaUserLinkingEnabled = metaUserLinkingEnabled;
     new Handler(Looper.getMainLooper()).post(new Runnable() {
       @Override
       public void run() {

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentiancePackage.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentiancePackage.java
@@ -3,21 +3,52 @@ package com.sentiance.react.bridge;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
-
-import android.util.Log;
-
+import com.sentiance.sdk.MetaUserLinker;
+import com.sentiance.sdk.OnSdkStatusUpdateHandler;
+import com.sentiance.sdk.SdkStatus;
 
 public class RNSentiancePackage implements ReactPackage {
+
+	private final CountDownLatch metaUserLinkLatch = new CountDownLatch(1);
+	private MetaUserLinker sentianceModuleMetaUserLinker = null;
+	private OnSdkStatusUpdateHandler sentianceModuleOnSdkStatusUpdateHandler = null;
+
+	private OnSdkStatusUpdateHandler onSdkStatusUpdateHandler = new OnSdkStatusUpdateHandler() {
+		@Override
+		public void onSdkStatusUpdate(SdkStatus status) {
+			if (sentianceModuleOnSdkStatusUpdateHandler != null)
+				sentianceModuleOnSdkStatusUpdateHandler.onSdkStatusUpdate(status);
+		}
+	};
+
+	private MetaUserLinker metaUserLinker = new MetaUserLinker() {
+		@Override
+		public boolean link(String installId) {
+			try {
+				metaUserLinkLatch.await();
+				return sentianceModuleMetaUserLinker.link(installId);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+				return false;
+			}
+		}
+	};
+
 	@Override
 	public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
 		List<NativeModule> modules = new ArrayList<>();
-		modules.add(new RNSentianceModule(reactContext));
+		RNSentianceModule rnSentianceModule = new RNSentianceModule(reactContext);
+		modules.add(rnSentianceModule);
+		sentianceModuleOnSdkStatusUpdateHandler = rnSentianceModule.getSdkStatusUpdateHandler();
+		sentianceModuleMetaUserLinker = rnSentianceModule.getMetaUserLinker();
+		metaUserLinkLatch.countDown();
 		return modules;
 	}
 
@@ -29,5 +60,14 @@ public class RNSentiancePackage implements ReactPackage {
 	@Override
 	public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
 		return Collections.emptyList();
+	}
+
+	public OnSdkStatusUpdateHandler getOnSdkStatusUpdateHandler() {
+		return onSdkStatusUpdateHandler;
+	}
+
+
+	public MetaUserLinker getMetaUserLinker() {
+		return metaUserLinker;
 	}
 }


### PR DESCRIPTION
If SDK is initialised natively, meta-user and SDK status events are not delivered to JS. To fix this issue when SDK is being initialised natively meta-user and sdk-status call backs are passed to react-bridge which will emit appropriate events for JS.

Meta user callback is invoked even before JS initialises, added wait logic and hasActiveCatalystInstance check before sending events to JS.