### PR TITLE
Feature/android notification update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ __Configuring capabilities__
   	```
 4. Configure foreground notification, Add the following lines to application's `AndroidManifest.xml` file inside `<application>` tag:
   	```xml
-    <meta-data android:name="com.sentiance.sdk.notification_title" android:resource="Notification Title"/>
-    <meta-data android:name="com.sentiance.sdk.notification_text" android:value="Notification Message"/>
-    <meta-data android:name="com.sentiance.sdk.notification_icon" android:resource="@mipmap/ic_launcher"/>
-    <meta-data android:name="com.sentiance.sdk.notification_channel_name" android:value="Notification Channel Name"/>
-    <meta-data android:name="com.sentiance.sdk.notification_channel_id" android:value="Sentiance"/>
+    <meta-data android:name="com.sentiance.react.bridge.notification_title" android:resource="@string/app_name"/>
+    <meta-data android:name="com.sentiance.react.bridge.notification_text" android:value="Touch to open."/>
+    <meta-data android:name="com.sentiance.react.bridge.notification_icon" android:resource="@mipmap/ic_launcher"/>
+    <meta-data android:name="com.sentiance.react.bridge.notification_channel_name" android:value="Sentiance"/>
+    <meta-data android:name="ccom.sentiance.react.bridge.notification_channel_id" android:value="sentiance"/>
   	```
 
 

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -173,12 +173,12 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
         info = reactContext.getPackageManager().getApplicationInfo(
                 reactContext.getPackageName(), PackageManager.GET_META_DATA);
         if(title==null)
-          title = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_title",defaultTitle);
+          title = getStringMetadataFromManifest(info, "com.sentiance.react.bridge.notification_title",defaultTitle);
         if(message==null)
-          message = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_text",defaultMessage);
-        channelName = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_channel_name",channelName);
-        icon  = getIntMetadataFromManifest(info, "com.sentiance.sdk.notification_icon",icon);
-        channelId  = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_channel_id",channelId);
+          message = getStringMetadataFromManifest(info, "com.sentiance.react.bridge.notification_text",defaultMessage);
+        channelName = getStringMetadataFromManifest(info, "com.sentiance.react.bridge.notification_channel_name",channelName);
+        icon  = getIntMetadataFromManifest(info, "com.sentiance.react.bridge.notification_icon",icon);
+        channelId  = getStringMetadataFromManifest(info, "com.sentiance.react.bridge.notification_channel_id",channelId);
       }catch (PackageManager.NameNotFoundException e){
         if(title==null)
           title=defaultTitle;

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -164,7 +164,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
       String appName = reactContext.getApplicationInfo().loadLabel(reactContext.getPackageManager()).toString();
       String  channelName = "Journeys";
       Integer icon = reactContext.getApplicationInfo().icon;
-      String channelId = "Journeys";
+      String channelId = "journeys";
       String defaultTitle = appName + " is running";
       String defaultMessage = "Touch to open";
 
@@ -524,7 +524,9 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
     Object obj = info.metaData.get(name);
     if (obj instanceof String) {
       return (String)obj;
-    } else {
+    } else if (obj instanceof Integer) {
+      return reactContext.getString((Integer)obj);
+    }else {
       return defaultValue;
     }
   }

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -178,7 +178,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
           message = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_text",defaultMessage);
         channelName = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_channel_name",channelName);
         icon  = getIntMetadataFromManifest(info, "com.sentiance.sdk.notification_icon",icon);
-        channelId  = getStringMetadataFromManifest(info, "com.sentiance.sdk.channel_id",channelId);
+        channelId  = getStringMetadataFromManifest(info, "com.sentiance.sdk.notification_channel_id",channelId);
       }catch (PackageManager.NameNotFoundException e){
         if(title==null)
           title=defaultTitle;


### PR DESCRIPTION
Notification contents can be configured from AndroidManifest.xml file.

With this change notification_icon should be specified in AndroidManifest.xml
i.e:

`<meta-data android:name="com.sentiance.react.bridge.notification_icon"android:resource="@mipmap/notification_icon"/>
`