### PR TITLE
subscription names updated

### DIFF
--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -22,7 +22,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"SDKStatusUpdate", @"TripTimeout", @"SDKMetaUserLink", @"UserActivity"];
+    return @[@"SDKStatusUpdate", @"SDKTripTimeout", @"SDKMetaUserLink", @"SDKUserActivityUpdate"];
 }
 
 // Will be called when this module's first listener is added.
@@ -380,7 +380,7 @@ RCT_EXPORT_METHOD(deleteKeychainEntries:(RCTPromiseResolveBlock)resolve rejecter
     __weak typeof(self) weakSelf = self;
     [[SENTSDK sharedInstance] setTripTimeOutListener:^ {
         if (weakSelf.hasListeners) {
-            [weakSelf sendEventWithName:@"TripTimeout" body:nil];
+            [weakSelf sendEventWithName:@"SDKTripTimeout" body:nil];
         }
     }];
 }
@@ -390,7 +390,7 @@ RCT_EXPORT_METHOD(deleteKeychainEntries:(RCTPromiseResolveBlock)resolve rejecter
     [[SENTSDK sharedInstance] setUserActivityListerner:^(SENTUserActivity *userActivity) {
         NSDictionary *userActivityDict = [self convertUserActivityToDict:userActivity];
         if(weakSelf.hasListeners) {
-            [weakSelf sendEventWithName:@"UserActivity" body:userActivityDict];
+            [weakSelf sendEventWithName:@"SDKUserActivityUpdate" body:userActivityDict];
         }
     }];
 }


### PR DESCRIPTION
Updated iOS subscriptions name to make it consistent and compatible with android.

This change will effect the following subscriptions:
Enclosing app should update their subscriptions like.

`TripTimeout` to `SDKTripTimeout`
`UserActivity` to `SDKUserActivityUpdate`
