### PR TITLE
Feature/ios subscriptions fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,66 @@ __Configuring capabilities__
 
 ![iOS Background Modes](./assets/ios-background-modes.png)
 
+#### Native initialization
+
+In your `AppDelegate` add the following:
+
+  ```objective-c
+  #import <React/RCTBundleURLProvider.h>
+  #import <React/RCTRootView.h>
+  @import SENTSDK;
+  #import <RNSentiance.h>
+  ```
+
+```objective-c
+-(BOOL) application: (UIApplication * ) application didFinishLaunchingWithOptions: (NSDictionary * ) launchOptions {
+  NSURL * jsCodeLocation;
+
+  jsCodeLocation = [
+    [NSBundle mainBundle] URLForResource: @ "main"
+    withExtension: @ "jsbundle"
+  ];
+
+  RCTBridge * bridge = [
+    [RCTBridge alloc] initWithBundleURL: jsCodeLocation
+    moduleProvider: nil
+    launchOptions: launchOptions
+  ];
+
+  RNSentiance * sentiance = [bridge moduleForClass: RNSentiance.class];
+
+  NSString * APP_ID = @ "_YOUR_APP_ID_";
+  NSString * SECRET = @ "_YOUR_APP_ID_SECRET_";
+
+  SENTConfig * config = [
+    [SENTConfig alloc] initWithAppId: APP_ID secret: SECRET link: sentiance.getMetaUserLinker launchOptions: launchOptions
+  ];
+  
+  [config setDidReceiveSdkStatusUpdate: sentiance.getSdkStatusUpdateHandler];
+
+  [[SENTSDK sharedInstance] initWithConfig:config success :^{
+    [self startSentianceSdk];
+  } failure:^(SENTInitIssue issue) {
+    NSLog(@"Failure issue: %lu", (unsigned long)issue);
+  }];
+
+  return YES;
+}
+
+- (void)startSentianceSdk {
+  [[SENTSDK sharedInstance] start:^(SENTSDKStatus *status) {
+    if ([status startStatus] == SENTStartStatusStarted) {
+      NSLog(@"SDK started properly");
+    } else if ([status startStatus] == SENTStartStatusPending) {
+      NSLog(@"Something prevented the SDK to start properly. Once fixed, the SDK will start automatically");
+    }
+    else {
+      NSLog(@"SDK did not start");
+    }
+  }];
+
+```
+
 
 #### Android
 

--- a/ios/RNSentiance.h
+++ b/ios/RNSentiance.h
@@ -1,7 +1,10 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#import <SENTSDK/SENTSDK.h>
 
 @interface RNSentiance : RCTEventEmitter <RCTBridgeModule>
-
+typedef void (^SdkStatusHandler)(SENTSDKStatus *status);
+- (MetaUserLinker) getMetaUserLinker;
+- (SdkStatusHandler) getSdkStatusUpdateHandler;
 @end


### PR DESCRIPTION
If SDK is initialised natively, meta-user and SDK status events are not delivered to JS. To fix this issue when SDK is initialised natively meta-user and SDK-status code blocks are passed to RNSentiance module from `AppDelegate`.
