### PR TITLE
Set up CircleCI for publishing prerelease packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.9.1
+    steps:
+      - add_ssh_keys
+      - checkout
+      - run:
+          name: Git config
+          command: |
+            git config user.email "dev@sentiance.com"
+            git config user.name "CircleCI"
+      - run:
+          name: Version bump
+          command: |
+            PATCH_LEVEL=`echo $CIRCLE_TAG | cut -d"_" -f2`
+            git checkout develop
+            npm version $PATCH_LEVEL
+            git push origin develop
+      - run:
+          name: Publish package and trigger Journeys
+          command: |
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+            npm publish
+      
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^prerelease_(prepatch|preminor|premajor)_(android|ios)_.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
This is a CircleCI configuration to automatically publish prerelease packages to the registry. The workflow is based on what was discussed previously:
1. A change is first made on a feature branch and submitted for PR.
2. The change is reviewed and merged to develop.
3. The merged commit is tagged as follows: prerelease_(prepatch|preminor|premajor)_(android|ios)_x.y.z
4. CircleCI workflow will run based on the matching tag, bump the appropriate version, and publish the package.