### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { EventSubscriptionVendor } from "react-native";
 
 declare module "react-native-sentiance" {
   interface RNSentianceConstructor extends EventSubscriptionVendor {
-    init(appId: string, secret: string, baseURL: string): Promise<any>;
+    init(appId: string, secret: string, baseURL: string, autoStart: boolean): Promise<any>;
     initWithUserLinkingEnabled(
       appId: string,
       secret: string,


### PR DESCRIPTION
Summary :  
Sentiance SDK Initialisation method in Android (native) requires a param called 'autoStart" (boolean param) in the method definition.
check this path : android-> src -> java -> RNSentianceModule.java -> 

public void init(final String appId, final String appSecret, final String baseURL, final boolean autoStart, final Promise promise) { ...}

but in the npm package in the index.d.ts the "init" method is missing the "autoStart" param.

So the initialisation step is broken in this version.