### PR TITLE
Feature/sentiance ios sdk 5.6.0 rc1

### DIFF
--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -487,7 +487,18 @@ RCT_EXPORT_METHOD(getUserActivity:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
 
 RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [self reset:resolve rejecter:reject];
+    [[SENTSDK sharedInstance] reset:^{ resolve() } failure:^(SENTResetFailureReason reason) {
+        switch(reason) {
+            case SENTResetFailureReasonInitInProgress:
+                reject(@"InitInProgress")
+                break;
+            case SENTResetFailureReasonResetting:
+                reject(@"Resetting")
+                break;
+            default:
+                reject(@"Unknown")
+        }
+    }];
 }
 
 -(void)deleteAllKeysForSecClass:(CFTypeRef)secClass {

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -632,6 +632,8 @@ RCT_EXPORT_METHOD(getUserActivity:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
             return @"INIT_IN_PROGRESS";
         case SENTInitialized:
             return @"INITIALIZED";
+        case SENTResetting:
+            return @"RESETTING";
     }
 }
 

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -485,6 +485,11 @@ RCT_EXPORT_METHOD(getUserActivity:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
     }
 }
 
+RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self reset:resolve rejecter:reject];
+}
+
 -(void)deleteAllKeysForSecClass:(CFTypeRef)secClass {
     NSMutableDictionary* dict = [NSMutableDictionary dictionary];
     [dict setObject:(__bridge id)secClass forKey:(__bridge id)kSecClass];

--- a/ios/SENTSDK.podspec
+++ b/ios/SENTSDK.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
     s.name              = 'SENTSDK'
-    s.version           = '5.5.5'
+    s.version           = '5.6.0-rc1'
     s.summary           = 'The Sentiance iOS SDK.'
     s.homepage          = 'https://sentiance.com/'
 
     s.author            = { 'Name' => 'support@sentiance.com' }
     s.license           = { :type => 'MIT' }
     s.platform          = :ios
-    s.source            = { :http => 'https://s3-eu-west-1.amazonaws.com/sentiance-sdk/ios/transport/SENTSDK-5.5.5.framework.zip' }
+    s.source            = { :http => 'https://sentiance-u1-sdk-downloads.s3-eu-west-1.amazonaws.com/ios/SENTSDK-5.6.0-rc1.framework.zip' }
     s.ios.deployment_target = '9.0'
     s.frameworks = 'CoreMotion', 'SystemConfiguration', 'CoreLocation', 'Foundation', 'CallKit', 'CoreTelephony', 'CoreData'
     s.libraries = 'z'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "react-native-sentiance",
-  "version": "3.0.7",
+  "version": "3.1.0-rc.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sentiance",
-  "version": "3.0.7",
+  "version": "3.1.0-rc.0",
   "description": "React Native library for the Sentiance SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Port the reset function from iOS SDK.

For Android side, @sebouh00 has it on his branch https://github.com/sentiance/react-native-sentiance/compare/develop...feature/sdk_reset

 Can we merge these two and release a RC version?
Then on Journeys Alpha, we can reference this RC version. Thanks. 