### PR TITLE
Develop (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2020-02-06
+### Added
+- `reset` method to reset the Sentiance SDK
+
+### Changed
+- Upgrade Android SDK to [4.14.0](https://docs.sentiance.com/sdk/changelog/android#4-14-0-31-jan-2020)
+- Upgrade iOS SDK to [5.6.0](https://docs.sentiance.com/sdk/changelog/ios#5-6-0-5-feb-2020)
+
+## [3.0.8] - 2020-01-16
+### Changed
+- Upgrade Android SDK to [4.13.0](https://docs.sentiance.com/sdk/changelog/android#4-13-0-6-jan-2020)
+
+## [3.0.7] - 2019-11-20
+### Added
+- The ability to update SDK foreground notification. This is only applicable to Android.
+- Send `SDKUserLink` event during initialization if user linking is enabled
+- Support subscriptions for user activity updates
+- Support the auto-start option when initializing the Sentiance SDK
+
+### Changed
+- Upgrade iOS SDK to [5.5.5](https://docs.sentiance.com/sdk/changelog/ios#5-5-5-13-nov-2019)
+
 ## [3.0.0] - 2019-08-01
 ### Added
-- Added `listenUserActivity` method
-- Added `initWithUserLinking` to expose the user linking [feature](https://docs.sentiance.com/guide/user-linking)
-- Added `initWithBaseURL` to initialize the SDK against another regional [API](https://docs.sentiance.com/sdk/api-reference/ios/sentconfig-1#sentconfig-api)
-- Added `getInitState` to retreive the init state of the SDK [link](https://docs.sentiance.com/sdk/api-reference/ios/sentsdk#getinitstate)
+- `listenUserActivity` method
+- `initWithUserLinking` to expose the user linking [feature](https://docs.sentiance.com/guide/user-linking)
+- `initWithBaseURL` to initialize the SDK against another regional [API](https://docs.sentiance.com/sdk/api-reference/ios/sentconfig-1#sentconfig-api)
+- `getInitState` to retreive the init state of the SDK [link](https://docs.sentiance.com/sdk/api-reference/ios/sentsdk#getinitstate)
 - Start maintaining a CHANGELOG.md
 
 ### Changed

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module "react-native-sentiance" {
     ): Promise<any>;
     start(): Promise<any>;
     stop(): Promise<any>;
+    reset(): Promise<any>;
     getInitState(): Promise<any>;
     getSdkStatus(): Promise<any>;
     getVersion(): Promise<any>;


### PR DESCRIPTION
* Update index.d.ts

Summary :  
Sentiance SDK Initialisation method in Android (native) requires a param called 'autoStart" (boolean param) in the method definition.
check this path : android-> src -> java -> RNSentianceModule.java -> 

public void init(final String appId, final String appSecret, final String baseURL, final boolean autoStart, final Promise promise) { ...}

but in the npm package in the index.d.ts the "init" method is missing the "autoStart" param.

So the initialisation step is broken in this version.

* Rename autoStart to shouldStart for Android

* Typings should consistently use shouldStart instead of autoStart

* Update and auto format README

* Update world Android SDK version to 4.14.0

* Android SDK reset function binding (#113)

* Fix payload submission on Android

* Support SDK reset on Android

* Update readme. add reset error names

Co-authored-by: Sebouh Aguehian <sebouh00@gmail.com>

* Update ios sdk to 5.6.0 & Reset function binding (#112)

* bind the reset function

Update ios sdk version to 5.6.0

* bug fix

* standardize error codes

* Added defaults

* 3.1.0 Upgraded iOS SDK to 5.6.0 Binded the Reset functionality

* Add reset typing (#115)

Co-authored-by: Jiri Crispeyn <jiri.crispeyn@gmail.com>

* Feature/update change log (#119)

* Update changelog

* Update SDKUserLink

* formatting the changelog

* foreground notification is android only

Co-authored-by: Martan Toupchi <martan.toupchi@gmail.com>
Co-authored-by: Jiri Crispeyn <jiri.crispeyn@gmail.com>
Co-authored-by: Sebouh Aguehian <sebouh00@gmail.com>
Co-authored-by: Tao Huang <tao.huang@sentiance.com>