### PR TITLE
Allow baseURL to be null as per the docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,13 +5,13 @@ declare module "react-native-sentiance" {
     init(
       appId: string,
       secret: string,
-      baseURL: string,
+      baseURL: string | null,
       shouldStart: boolean
     ): Promise<any>;
     initWithUserLinkingEnabled(
       appId: string,
       secret: string,
-      baseURL: string,
+      baseURL: string | null,
       shouldStart: boolean
     ): Promise<any>;
     start(): Promise<any>;


### PR DESCRIPTION
The docs claim that the `baseURL` parameter in `init()` and `initWithUserLinkingEnabled()` can be `null`: https://github.com/sentiance/react-native-sentiance#initialize-and-start-the-sentiance-sdk

The TypeScript types do not reflect this. 

This PR makes the `baseURL` parameter nullable in the TS-definitions of `init()` and `initWithUserLinkingEnabled()`