### PR TITLE
Use a new countdown latch for every link request

### DIFF
--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -33,10 +33,11 @@ public class RNSentianceHelper {
     private static final String TAG = "RNSentianceHelper";
     private static RNSentianceHelper rnSentianceHelper;
 
-    private final CountDownLatch userLinkLatch = new CountDownLatch(1);
     private final RNSentianceEmitter emitter;
     private final WeakReference<Context> weakContext;
+  
     private Boolean userLinkResult = false;
+    private volatile CountDownLatch userLinkLatch;
 
     private OnSdkStatusUpdateHandler onSdkStatusUpdateHandler = new OnSdkStatusUpdateHandler() {
         @Override
@@ -50,6 +51,7 @@ public class RNSentianceHelper {
         @Override
         public boolean link(String installId) {
             Log.d(TAG, "User Link");
+            userLinkLatch = new CountDownLatch(1);
             emitter.sendUserLinkEvent(installId);
             try {
                 userLinkLatch.await();
@@ -78,7 +80,11 @@ public class RNSentianceHelper {
 
     void userLinkCallback(final Boolean linkResult) {
         userLinkResult = linkResult;
-        userLinkLatch.countDown();
+        
+        CountDownLatch latch = userLinkLatch;
+        if (latch != null) {
+            latch.countDown();
+        }
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})


### PR DESCRIPTION
During the lifetime of the app process, there can be more than one link request if the SDK is reset at least once. Each request must have its own latch to wait on, otherwise subsequent link requests will skip waiting on a zeroed latch.