### PR TITLE
Bugfix/fix broken user linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ sentianceEmitter = rnSentianceEmitter.addListener("SDKUserLink", id => {
 });
 ```
 
+_NOTE: `SDKUserLink` listener must be set before calling `RNSentiance.initWithUserLinkingEnabled`._
+
 #### Resetting the SDK
 
 To delete the Sentiance user and its data from the device, you can reset the SDK by calling `RNSentiance.reset`. This allows you to create a new Sentiance user by reinitializing the SDK, and link it to a new third party ID.

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -108,30 +108,21 @@ RCT_EXPORT_MODULE()
     if(self.userLinker != nil) return self.userLinker;
 
     __weak typeof(self) weakSelf = self;
-    __block BOOL timeout = false;
-
+    
     self.userLinker = ^(NSString *installId, void (^linkSuccess)(void),
                         void (^linkFailed)(void)) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 
-            //set timeout for listeners to set
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                timeout = YES;
-            });
-
             //wait for JS listener
-            while(!weakSelf.hasListeners && !timeout){}
-
-            if(timeout){
-                linkFailed();
-            }else{
-                weakSelf.userLinkSuccess = linkSuccess;
-                weakSelf.userLinkFailed = linkFailed;
-                [weakSelf sendEventWithName:@"SDKUserLink" body:[weakSelf convertInstallIdToDict:installId]];
-            }
+            while(!weakSelf.hasListeners){}
+            
+            weakSelf.userLinkSuccess = linkSuccess;
+            weakSelf.userLinkFailed = linkFailed;
+            [weakSelf sendEventWithName:@"SDKUserLink" body:[weakSelf convertInstallIdToDict:installId]];
+            
         });
     };
-
+    
     return self.userLinker;
 }
 


### PR DESCRIPTION
The timeout used for listeners to set was buggy, after first initialization timeout becomes `true` and it remains `
true` for all subsequent initializations.

- Remove unnecessary timeout while waiting for listeners to set.
- Update documentation.
