### PR TITLE
Restore top most activity from notification

### DIFF
--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -256,7 +256,7 @@ public class RNSentianceHelper {
         if (launchIntent == null) {
             launchIntent = new Intent();
         }
-        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        launchIntent.setPackage(null);
         return PendingIntent.getActivity(context, 0, launchIntent, 0);
     }
 


### PR DESCRIPTION
When clicking the notification, this change brings the top most activity to view, as opposed to clearing all activities and opening the launcher activity. If no activity is open, this change simply starts the main activity.