### PR TITLE
Three new methods for native initialization flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- enableNativeInitialization
+- disableNativeInitialization
+- isNativeInitializationEnabled
+
 ## [4.1.0] - 2020-09-07
 ### Fixed
 - Broken startWithStopDate on android.

--- a/README.md
+++ b/README.md
@@ -565,3 +565,14 @@ try {
   console.error(err)
 }
 ```
+
+###### Determine if the app should initialize Sentiance SDK natively
+
+To make user linking possible, the first SDK initialization should be executed in JS. After it completes successfully,
+```await RNSentiance.enableNativeInitialization()``` should be invoked.
+
+In AppDelegate (iOS) and MainApplication (Android), ```isNativeInitializationEnabled``` can be used to determine if the SDK should be initialized natively.
+
+To disable native initialization, invoke ```await RNSentiance.disableNativeInitialization()```.
+
+Please refer to our [example app](https://github.com/sentiance/react-native-sentiance-example) for a complete usage.

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class RNSentianceHelper {
 
-    public static final String SDK_NATIVE_INIT_FLAG = "SDK_NATIVE_INIT_FLAG";
+    private static final String SDK_NATIVE_INIT_FLAG = "SDK_NATIVE_INIT_FLAG";
     private static final String MY_PREFS_NAME = "RNSentianceHelper";
     private static final String TAG = "RNSentianceHelper";
     private static RNSentianceHelper rnSentianceHelper;
@@ -128,9 +128,20 @@ public class RNSentianceHelper {
         return prefs.getString(key, defaultValue);
     }
 
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public Boolean isNativeInitializationEnabled() {
-      String nativeInitFlag = rnSentianceHelper.getValueForKey(SDK_NATIVE_INIT_FLAG, "");
-      return nativeInitFlag.equals("enabled");
+        String nativeInitFlag = rnSentianceHelper.getValueForKey(SDK_NATIVE_INIT_FLAG, "");
+        return nativeInitFlag.equals("enabled");
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void enableNativeInitialization() {
+        setValueForKey(SDK_NATIVE_INIT_FLAG, "enabled");
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void disableNativeInitialization() {
+        setValueForKey(SDK_NATIVE_INIT_FLAG, "");
     }
 
     private void initializeAndStartSentianceSDK(String appId, String appSecret,

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -29,8 +29,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class RNSentianceHelper {
 
-    private static final String SDK_NATIVE_INITIALIZATION_FLAG = "SENTSDK_NATIVE_INITIALIZATION_FLAG";
-    private static final String SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME = "SENTSDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME";
+    public static final String SDK_NATIVE_INIT_FLAG = "SDK_NATIVE_INIT_FLAG";
     private static final String MY_PREFS_NAME = "RNSentianceHelper";
     private static final String TAG = "RNSentianceHelper";
     private static RNSentianceHelper rnSentianceHelper;
@@ -129,31 +128,9 @@ public class RNSentianceHelper {
         return prefs.getString(key, defaultValue);
     }
 
-    @SuppressWarnings({"unused", "WeakerAccess"})
-    public void setFlagForNativeInitializationWithName(@Nullable String name, Boolean value) {
-      Context context = weakContext.get();
-      if (context == null) return;
-
-      String prefsName = getValueForKey(SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME, MY_PREFS_NAME);
-
-      if (name != null && !prefsName.equals(name)) {
-        setValueForKey(SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME, name);
-        prefsName = name;
-      }
-
-      SharedPreferences prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
-      prefs.edit().putBoolean(SDK_NATIVE_INITIALIZATION_FLAG, value).apply();
-    }
-
-    @SuppressWarnings({"unused", "WeakerAccess"})
-    public Boolean getFlagForNativeInitialization() {
-      Context context = weakContext.get();
-      if (context == null) return false;
-
-      String prefsName = getValueForKey(SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME, MY_PREFS_NAME);
-      SharedPreferences prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
-
-      return prefs.getBoolean(SDK_NATIVE_INITIALIZATION_FLAG, false);
+    public Boolean isNativeInitializationEnabled() {
+      String nativeInitFlag = rnSentianceHelper.getValueForKey(SDK_NATIVE_INIT_FLAG, "");
+      return nativeInitFlag.equals("enabled");
     }
 
     private void initializeAndStartSentianceSDK(String appId, String appSecret,

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -29,6 +29,8 @@ import java.util.concurrent.CountDownLatch;
 
 public class RNSentianceHelper {
 
+    private static final String SDK_NATIVE_INITIALIZATION_FLAG = "SENTSDK_NATIVE_INITIALIZATION_FLAG";
+    private static final String SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME = "SENTSDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME";
     private static final String MY_PREFS_NAME = "RNSentianceHelper";
     private static final String TAG = "RNSentianceHelper";
     private static RNSentianceHelper rnSentianceHelper;
@@ -125,6 +127,33 @@ public class RNSentianceHelper {
         if (context == null) return defaultValue;
         SharedPreferences prefs = context.getSharedPreferences(MY_PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getString(key, defaultValue);
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void setFlagForNativeInitializationWithName(@Nullable String name, Boolean value) {
+      Context context = weakContext.get();
+      if (context == null) return;
+
+      String prefsName = getValueForKey(SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME, MY_PREFS_NAME);
+
+      if (name != null && !prefsName.equals(name)) {
+        setValueForKey(SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME, name);
+        prefsName = name;
+      }
+
+      SharedPreferences prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
+      prefs.edit().putBoolean(SDK_NATIVE_INITIALIZATION_FLAG, value).apply();
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public Boolean getFlagForNativeInitialization() {
+      Context context = weakContext.get();
+      if (context == null) return false;
+
+      String prefsName = getValueForKey(SDK_NATIVE_INITIALIZATION_FLAG_PREFS_NAME, MY_PREFS_NAME);
+      SharedPreferences prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE);
+
+      return prefs.getBoolean(SDK_NATIVE_INITIALIZATION_FLAG, false);
     }
 
     private void initializeAndStartSentianceSDK(String appId, String appSecret,

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -33,7 +33,6 @@ import android.location.Location;
 import android.util.Log;
 import androidx.annotation.Nullable;
 
-import java.util.Date;
 import java.util.Map;
 
 public class RNSentianceModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
@@ -166,6 +165,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
     sdk.reset(new ResetCallback() {
       @Override
       public void onResetSuccess() {
+        rnSentianceHelper.setFlagForNativeInitializationWithName(null, false);
         promise.resolve(true);
       }
 
@@ -617,6 +617,27 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   public void getValueForKey(String key, String defaultValue, Promise promise) {
     String value = rnSentianceHelper.getValueForKey(key, defaultValue);
     promise.resolve(value);
+  }
+
+  @ReactMethod
+  @SuppressWarnings("unused")
+  public void isNativeInitializationEnabled(Promise promise) {
+    Boolean value = rnSentianceHelper.getFlagForNativeInitialization();
+    promise.resolve(value);
+  }
+
+  @ReactMethod
+  @SuppressWarnings("unused")
+  public void enableNativeInitialization(@Nullable String name, Promise promise) {
+    rnSentianceHelper.setFlagForNativeInitializationWithName(name, true);
+    promise.resolve(true);
+  }
+
+  @ReactMethod
+  @SuppressWarnings("unused")
+  public void disableNativeInitialization(@Nullable String name, Promise promise) {
+    rnSentianceHelper.setFlagForNativeInitializationWithName(name, false);
+    promise.resolve(true);
   }
 
   private boolean isSdkInitialized() {

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -165,7 +165,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
     sdk.reset(new ResetCallback() {
       @Override
       public void onResetSuccess() {
-        rnSentianceHelper.setFlagForNativeInitializationWithName(null, false);
+        rnSentianceHelper.setValueForKey(RNSentianceHelper.SDK_NATIVE_INIT_FLAG, "");
         promise.resolve(true);
       }
 
@@ -622,21 +622,20 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   @ReactMethod
   @SuppressWarnings("unused")
   public void isNativeInitializationEnabled(Promise promise) {
-    Boolean value = rnSentianceHelper.getFlagForNativeInitialization();
-    promise.resolve(value);
+    promise.resolve(rnSentianceHelper.isNativeInitializationEnabled());
   }
 
   @ReactMethod
   @SuppressWarnings("unused")
-  public void enableNativeInitialization(@Nullable String name, Promise promise) {
-    rnSentianceHelper.setFlagForNativeInitializationWithName(name, true);
+  public void enableNativeInitialization(Promise promise) {
+    rnSentianceHelper.setValueForKey(RNSentianceHelper.SDK_NATIVE_INIT_FLAG, "enabled");
     promise.resolve(true);
   }
 
   @ReactMethod
   @SuppressWarnings("unused")
-  public void disableNativeInitialization(@Nullable String name, Promise promise) {
-    rnSentianceHelper.setFlagForNativeInitializationWithName(name, false);
+  public void disableNativeInitialization(Promise promise) {
+    rnSentianceHelper.setValueForKey(RNSentianceHelper.SDK_NATIVE_INIT_FLAG, "");
     promise.resolve(true);
   }
 

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceModule.java
@@ -165,7 +165,7 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
     sdk.reset(new ResetCallback() {
       @Override
       public void onResetSuccess() {
-        rnSentianceHelper.setValueForKey(RNSentianceHelper.SDK_NATIVE_INIT_FLAG, "");
+        rnSentianceHelper.disableNativeInitialization();
         promise.resolve(true);
       }
 
@@ -628,14 +628,14 @@ public class RNSentianceModule extends ReactContextBaseJavaModule implements Lif
   @ReactMethod
   @SuppressWarnings("unused")
   public void enableNativeInitialization(Promise promise) {
-    rnSentianceHelper.setValueForKey(RNSentianceHelper.SDK_NATIVE_INIT_FLAG, "enabled");
+    rnSentianceHelper.enableNativeInitialization();
     promise.resolve(true);
   }
 
   @ReactMethod
   @SuppressWarnings("unused")
   public void disableNativeInitialization(Promise promise) {
-    rnSentianceHelper.setValueForKey(RNSentianceHelper.SDK_NATIVE_INIT_FLAG, "");
+    rnSentianceHelper.disableNativeInitialization();
     promise.resolve(true);
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,8 +175,8 @@ declare module "react-native-sentiance" {
     updateSdkNotification(title: string, message: string): Promise<boolean>;
     addTripMetadata(metadata: MetadataObject): Promise<boolean>;
     isNativeInitializationEnabled(): Promise<boolean>;
-    enableNativeInitialization(name: string|null): Promise<boolean>;
-    disableNativeInitialization(name: string|null): Promise<boolean>;
+    enableNativeInitialization(): Promise<boolean>;
+    disableNativeInitialization(): Promise<boolean>;
   }
 
   export interface RNSentianceEventEmitter extends NativeEventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,8 +175,8 @@ declare module "react-native-sentiance" {
     updateSdkNotification(title: string, message: string): Promise<boolean>;
     addTripMetadata(metadata: MetadataObject): Promise<boolean>;
     isNativeInitializationEnabled(): Promise<boolean>;
-    enableNativeInitialization(name?: string): Promise<boolean>;
-    disableNativeInitialization(name?: string): Promise<boolean>;
+    enableNativeInitialization(name: string|null): Promise<boolean>;
+    disableNativeInitialization(name: string|null): Promise<boolean>;
   }
 
   export interface RNSentianceEventEmitter extends NativeEventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -174,6 +174,9 @@ declare module "react-native-sentiance" {
     submitDetections(): Promise<boolean>;
     updateSdkNotification(title: string, message: string): Promise<boolean>;
     addTripMetadata(metadata: MetadataObject): Promise<boolean>;
+    isNativeInitializationEnabled(): Promise<boolean>;
+    enableNativeInitialization(name?: string): Promise<boolean>;
+    disableNativeInitialization(name?: string): Promise<boolean>;
   }
 
   export interface RNSentianceEventEmitter extends NativeEventEmitter {

--- a/ios/RNSentiance.h
+++ b/ios/RNSentiance.h
@@ -13,4 +13,6 @@ typedef void (^SdkStatusHandler)(SENTSDKStatus *status);
 - (void) startSDKWithStopEpochTimeMs:(nullable NSNumber*) stopEpochTimeMs resolver:(RCTPromiseResolveBlock _Nullable )resolve  rejecter:(RCTPromiseRejectBlock _Nullable )reject;
 - (void) startSDK:(RCTPromiseResolveBlock _Nullable )resolve rejecter:(RCTPromiseRejectBlock _Nullable )reject;
 - (BOOL) isNativeInitializationEnabled;
+- (void) disableSDKNativeInitialization:(RCTPromiseResolveBlock _Nullable)resolve rejecter:(RCTPromiseRejectBlock _Nullable)reject;
+- (void) enableSDKNativeInitialization:(RCTPromiseResolveBlock _Nullable)resolve rejecter:(RCTPromiseRejectBlock _Nullable)reject;
 @end

--- a/ios/RNSentiance.h
+++ b/ios/RNSentiance.h
@@ -12,4 +12,5 @@ typedef void (^SdkStatusHandler)(SENTSDKStatus *status);
 - (void) setValueForKey:(NSString *)key value:(NSString *)value;
 - (void) startSDKWithStopEpochTimeMs:(nullable NSNumber*) stopEpochTimeMs resolver:(RCTPromiseResolveBlock _Nullable )resolve  rejecter:(RCTPromiseRejectBlock _Nullable )reject;
 - (void) startSDK:(RCTPromiseResolveBlock _Nullable )resolve rejecter:(RCTPromiseRejectBlock _Nullable )reject;
+- (BOOL) isNativeInitializationEnabled;
 @end

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -516,7 +516,9 @@ RCT_EXPORT_METHOD(getUserActivity:(RCTPromiseResolveBlock)resolve rejecter:(RCTP
 
 RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SENTSDK sharedInstance] reset:^{ resolve(@(YES)); } failure:^(SENTResetFailureReason reason) {
+    [[SENTSDK sharedInstance] reset:^{
+        [self setNativeInitializationEnabledFlag:nil enable:@"NO" resolver:resolve rejecter:reject];
+    } failure:^(SENTResetFailureReason reason) {
         NSString *message = @"Resetting the SDK failed";
         switch(reason) {
             case SENTResetFailureReasonInitInProgress:
@@ -629,6 +631,7 @@ RCT_EXPORT_METHOD(disableNativeInitialization:(nullable NSString *)name resolver
             } else {
                 [self setKeychainItem:existFlagServiceName key:flagKey value:enable];
             }
+            resolve(@(YES));
         } else {
             reject(@"protected_data_unavailable", @"Protected data not available yet. Retry operation", nil);
         }

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -606,9 +606,13 @@ RCT_EXPORT_METHOD(disableNativeInitialization:(RCTPromiseResolveBlock)resolve re
 
 - (NSString *) getNativeInitializationFilePath:(NSFileManager *)fileManager {
     NSString *docDir = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject].path;
-    NSString *sentianceDir = [docDir stringByAppendingPathComponent:@"RNSentiance"];
+    NSString *sentianceDir = [self getRNSentianceDirectoryPath:docDir];
     NSString* path = [sentianceDir stringByAppendingPathComponent:@"rnsentiance_initialize_natively"];
     return path;
+}
+
+- (NSString *) getRNSentianceDirectoryPath:(NSString *) docDir {
+    return [docDir stringByAppendingPathComponent:@"RNSentiance"];
 }
 
 - (BOOL)isNativeInitializationEnabled {
@@ -624,7 +628,7 @@ RCT_EXPORT_METHOD(disableNativeInitialization:(RCTPromiseResolveBlock)resolve re
 - (void)enableSDKNativeInitialization:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *docDir = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject].path;
-    NSString *sentianceDir = [docDir stringByAppendingPathComponent:@"RNSentiance"];
+    NSString *sentianceDir = [self getRNSentianceDirectoryPath:docDir];
     NSString* path = [self getNativeInitializationFilePath:fileManager];
     if([fileManager fileExistsAtPath:path]) {
         if (resolve) {
@@ -657,8 +661,10 @@ RCT_EXPORT_METHOD(disableNativeInitialization:(RCTPromiseResolveBlock)resolve re
     if([fileManager fileExistsAtPath:path]) {
         NSError *error;
         [fileManager removeItemAtPath:path error:&error];
-        if (error != nil && reject) {
-            reject(@"ERROR_REMOVE_FILE", error.description, nil);
+        if (error != nil) {
+            if (reject) {
+                reject(@"ERROR_REMOVE_FILE", error.description, nil);
+            }
         } else if (resolve) {
             resolve(@(YES));
         }

--- a/ios/RNSentiance.xcodeproj/project.pbxproj
+++ b/ios/RNSentiance.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9AE9AE342527BDFA0070A307 /* RNSentianceNativeInitialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AE9AE332527BDFA0070A307 /* RNSentianceNativeInitialization.m */; };
 		B3E7B58A1CC2AC0600A0062D /* RNSentiance.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNSentiance.m */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNSentiance.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNSentiance.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AE9AE322527BDD90070A307 /* RNSentianceNativeInitialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNSentianceNativeInitialization.h; sourceTree = "<group>"; };
+		9AE9AE332527BDFA0070A307 /* RNSentianceNativeInitialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentianceNativeInitialization.m; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNSentiance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNSentiance.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNSentiance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSentiance.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -50,6 +53,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				9AE9AE332527BDFA0070A307 /* RNSentianceNativeInitialization.m */,
+				9AE9AE322527BDD90070A307 /* RNSentianceNativeInitialization.h */,
 				B3E7B5881CC2AC0600A0062D /* RNSentiance.h */,
 				B3E7B5891CC2AC0600A0062D /* RNSentiance.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -95,6 +100,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -113,6 +119,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* RNSentiance.m in Sources */,
+				9AE9AE342527BDFA0070A307 /* RNSentianceNativeInitialization.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNSentianceNativeInitialization.h
+++ b/ios/RNSentianceNativeInitialization.h
@@ -1,0 +1,6 @@
+@interface RNSentianceNativeInitialization: NSObject
++ (RNSentianceNativeInitialization *)sharedObject;
+- (BOOL) isFlagFileExists;
+- (void) createFlagFile:(NSError **)error;
+- (void) removeFlagFile:(NSError **)error;
+@end

--- a/ios/RNSentianceNativeInitialization.m
+++ b/ios/RNSentianceNativeInitialization.m
@@ -1,0 +1,56 @@
+#import "RNSentianceNativeInitialization.h"
+
+@implementation RNSentianceNativeInitialization
+
++ (RNSentianceNativeInitialization *)sharedObject {
+    static RNSentianceNativeInitialization *rnSentianceNativeInitialization = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        rnSentianceNativeInitialization = [[self alloc] init];
+    });
+    return rnSentianceNativeInitialization;
+}
+
+- (NSString *) getRNSentianceDirectoryPath:(NSString *) docDir {
+    return [docDir stringByAppendingPathComponent:@"RNSentiance"];
+}
+
+- (NSString *) getNativeInitializationFilePath:(NSFileManager *)fileManager {
+    NSString *docDir = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject].path;
+    NSString *sentianceDir = [self getRNSentianceDirectoryPath:docDir];
+    NSString* path = [sentianceDir stringByAppendingPathComponent:@"rnsentiance_initialize_natively"];
+    return path;
+}
+
+- (BOOL)isFlagFileExists {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString* path = [self getNativeInitializationFilePath:fileManager];
+    if([fileManager fileExistsAtPath:path]) {
+        return YES;
+    } else {
+        return NO;
+    }
+}
+
+- (void)createFlagFile:(NSError **)error {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *docDir = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject].path;
+    NSString *sentianceDir = [self getRNSentianceDirectoryPath:docDir];
+    NSString* path = [self getNativeInitializationFilePath:fileManager];
+    
+    [fileManager createDirectoryAtPath:sentianceDir withIntermediateDirectories:YES
+                            attributes:@{NSFileProtectionKey:NSFileProtectionNone}
+                                 error:error];
+    
+    if (*error == nil) {
+        [fileManager createFileAtPath:path contents:nil attributes:@{NSFileProtectionKey:NSFileProtectionNone}];
+    }
+}
+
+- (void)removeFlagFile:(NSError **)error {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString* path = [self getNativeInitializationFilePath:fileManager];
+    [fileManager removeItemAtPath:path error:error];
+}
+
+@end


### PR DESCRIPTION
* enableNativeInitialization
   on Android: set the flag to sharedPreferences
   on iOS: create a plist file

* disableNativeInitialization
   on Android: clear the flag
   on iOS: delete the file

* isNativeInitializationEnabled
   on Andorid: check flag value
   on iOS: does file exist

Tested [on the example app](https://github.com/sentiance/react-native-sentiance-example/compare/native-initialization-flag?expand=1).