### PR TITLE
SDK1-1258: Fix native initialization if third party linking has not been completed yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.4.0] - 2021-04-19
+### Changed
+- Upgrade iOS SDK to [5.10.0](https://docs.sentiance.com/sdk/changelog/ios#5-10-0-14-apr-2021)
+- Upgrade Android SDK to [4.19.0](https://docs.sentiance.com/sdk/changelog/android#4-19-0-14-apr-2021)
+
+### Added
+- `isThirdPartyLinked` to determine whether third part linking has been completed successfully
+
+### Changed
+
 ## [4.3.1] - 2021-02-03
 ### Changed
 - Updated iOS integration doc

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
-        google()
+      google()
+      gradlePluginPortal()
     }
 
     dependencies {
@@ -26,14 +26,15 @@ android {
 }
 
 repositories {
+    google()
     mavenCentral()
+    gradlePluginPortal()
     maven {
         url "http://repository.sentiance.com"
     }
-    google()
 }
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api ('com.sentiance:sdk:4.18.0@aar') { transitive = true }
+    api ('com.sentiance:sdk:4.19.0@aar') { transitive = true }
 }

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -15,6 +15,7 @@ import androidx.core.app.NotificationCompat;
 
 import android.util.Log;
 
+import com.sentiance.sdk.InternalSentianceHelper;
 import com.sentiance.sdk.MetaUserLinker;
 import com.sentiance.sdk.OnInitCallback;
 import com.sentiance.sdk.OnSdkStatusUpdateHandler;
@@ -110,6 +111,19 @@ public class RNSentianceHelper {
     public void initializeSentianceSDKWithUserLinking(String appId, String appSecret, boolean shouldStart,
                                                       @Nullable String baseUrl, @Nullable OnInitCallback initCallback, @Nullable OnStartFinishedHandler startFinishedHandler) {
         initializeAndStartSentianceSDK(appId, appSecret, shouldStart, baseUrl, true, initCallback, startFinishedHandler);
+    }
+
+    public void initializeSentianceSDKIfUserLinkingCompleted(String appId, String appSecret, boolean shouldStart,
+                                                             @Nullable String baseUrl, @Nullable OnInitCallback initCallback, @Nullable OnStartFinishedHandler startFinishedHandler) {
+        if (isThirdPartyLinked()) {
+            initializeAndStartSentianceSDK(appId, appSecret, shouldStart, baseUrl, true, initCallback, startFinishedHandler);
+        }
+    }
+
+    public boolean isThirdPartyLinked() {
+        Context context = weakContext.get();
+        if (context == null) return false;
+        return InternalSentianceHelper.isThirdPartyLinked(context);
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})

--- a/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/react/bridge/RNSentianceHelper.java
@@ -113,10 +113,13 @@ public class RNSentianceHelper {
         initializeAndStartSentianceSDK(appId, appSecret, shouldStart, baseUrl, true, initCallback, startFinishedHandler);
     }
 
-    public void initializeSentianceSDKIfUserLinkingCompleted(String appId, String appSecret, boolean shouldStart,
-                                                             @Nullable String baseUrl, @Nullable OnInitCallback initCallback, @Nullable OnStartFinishedHandler startFinishedHandler) {
+    public boolean initializeSentianceSDKIfUserLinkingCompleted(String appId, String appSecret, boolean shouldStart,
+                                                                @Nullable String baseUrl, @Nullable OnInitCallback initCallback, @Nullable OnStartFinishedHandler startFinishedHandler) {
         if (isThirdPartyLinked()) {
             initializeAndStartSentianceSDK(appId, appSecret, shouldStart, baseUrl, true, initCallback, startFinishedHandler);
+            return true;
+        } else {
+          return false;
         }
     }
 

--- a/android/src/main/java/com/sentiance/sdk/InternalSentianceHelper.java
+++ b/android/src/main/java/com/sentiance/sdk/InternalSentianceHelper.java
@@ -1,0 +1,15 @@
+package com.sentiance.sdk;
+
+import android.content.Context;
+
+/**
+ * This is an internal helper class, it is not intended to be used externally.
+ */
+public class InternalSentianceHelper {
+  // hide constructor
+  private InternalSentianceHelper() {}
+
+  public static boolean isThirdPartyLinked(Context context) {
+    return Sentiance.getInstance(context).isThirdPartyLinked();
+  }
+}

--- a/ios/RNSentiance.h
+++ b/ios/RNSentiance.h
@@ -8,6 +8,8 @@ typedef void (^SdkStatusHandler)(SENTSDKStatus *status);
 - (MetaUserLinker) getUserLinker;
 - (SdkStatusHandler) getSdkStatusUpdateHandler;
 - (void) initSDK:(NSString *)appId secret:(NSString *)secret baseURL:(NSString *)baseURL shouldStart:(BOOL)shouldStart resolver:(RCTPromiseResolveBlock)resolve  rejecter:(RCTPromiseRejectBlock)reject;
+- (void) initSDKIfUserLinkingCompleted:(NSString *)appId secret:(NSString *)secret baseURL:(NSString *)baseURL shouldStart:(BOOL)shouldStart resolver:(RCTPromiseResolveBlock)resolve  rejecter:(RCTPromiseRejectBlock)reject;
+- (BOOL) isThirdPartyLinked;
 - (NSString *) getValueForKey:(NSString *)key value:(NSString *)defaultValue;
 - (void) setValueForKey:(NSString *)key value:(NSString *)value;
 - (void) startSDKWithStopEpochTimeMs:(nullable NSNumber*) stopEpochTimeMs resolver:(RCTPromiseResolveBlock _Nullable )resolve  rejecter:(RCTPromiseRejectBlock _Nullable )reject;

--- a/ios/RNSentiance.h
+++ b/ios/RNSentiance.h
@@ -8,7 +8,7 @@ typedef void (^SdkStatusHandler)(SENTSDKStatus *status);
 - (MetaUserLinker) getUserLinker;
 - (SdkStatusHandler) getSdkStatusUpdateHandler;
 - (void) initSDK:(NSString *)appId secret:(NSString *)secret baseURL:(NSString *)baseURL shouldStart:(BOOL)shouldStart resolver:(RCTPromiseResolveBlock)resolve  rejecter:(RCTPromiseRejectBlock)reject;
-- (void) initSDKIfUserLinkingCompleted:(NSString *)appId secret:(NSString *)secret baseURL:(NSString *)baseURL shouldStart:(BOOL)shouldStart resolver:(RCTPromiseResolveBlock)resolve  rejecter:(RCTPromiseRejectBlock)reject;
+- (BOOL) initSDKIfUserLinkingCompleted:(NSString *)appId secret:(NSString *)secret baseURL:(NSString *)baseURL shouldStart:(BOOL)shouldStart resolver:(RCTPromiseResolveBlock)resolve  rejecter:(RCTPromiseRejectBlock)reject;
 - (BOOL) isThirdPartyLinked;
 - (NSString *) getValueForKey:(NSString *)key value:(NSString *)defaultValue;
 - (void) setValueForKey:(NSString *)key value:(NSString *)value;

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -94,7 +94,7 @@ RCT_EXPORT_MODULE()
         resolver:(RCTPromiseResolveBlock)resolve
         rejecter:(RCTPromiseRejectBlock)reject
 {
-    BOOL isThirdPartyLinked = [self isNativeInitializationEnabled];
+    BOOL isThirdPartyLinked = [self isThirdPartyLinked];
     if (isThirdPartyLinked) {
         [self initSDK:appId secret:secret baseURL:baseURL shouldStart:shouldStart resolver:resolve rejecter:reject];
     }

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -87,7 +87,7 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (void) initSDKIfUserLinkingCompleted:(NSString *)appId
+- (BOOL) initSDKIfUserLinkingCompleted:(NSString *)appId
           secret:(NSString *)secret
          baseURL:(nullable NSString *)baseURL
      shouldStart:(BOOL)shouldStart
@@ -97,7 +97,9 @@ RCT_EXPORT_MODULE()
     BOOL isThirdPartyLinked = [self isThirdPartyLinked];
     if (isThirdPartyLinked) {
         [self initSDK:appId secret:secret baseURL:baseURL shouldStart:shouldStart resolver:resolve rejecter:reject];
+        return YES;
     }
+    return NO;
 }
 
 - (void) startSDK:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {

--- a/ios/RNSentiance.m
+++ b/ios/RNSentiance.m
@@ -4,6 +4,11 @@
 #import <SENTSDK/SENTPublicDefinitions.h>
 #import "RNSentianceNativeInitialization.h"
 
+@interface SENTSDK (Bindings)
+- (BOOL)userExists;
+- (BOOL)isThirdPartyLinked;
+@end
+
 @interface RNSentiance()
 
 @property (nonatomic, strong) void (^userLinkSuccess)(void);
@@ -79,6 +84,19 @@ RCT_EXPORT_MODULE()
         if (reject) {
             reject(e.name, e.reason, nil);
         }
+    }
+}
+
+- (void) initSDKIfUserLinkingCompleted:(NSString *)appId
+          secret:(NSString *)secret
+         baseURL:(nullable NSString *)baseURL
+     shouldStart:(BOOL)shouldStart
+        resolver:(RCTPromiseResolveBlock)resolve
+        rejecter:(RCTPromiseRejectBlock)reject
+{
+    BOOL isThirdPartyLinked = [self isNativeInitializationEnabled];
+    if (isThirdPartyLinked) {
+        [self initSDK:appId secret:secret baseURL:baseURL shouldStart:shouldStart resolver:resolve rejecter:reject];
     }
 }
 
@@ -643,6 +661,10 @@ RCT_EXPORT_METHOD(isVehicleCrashDetectionSupported:(NSString *)type
     
     BOOL supported = [[SENTSDK sharedInstance] isVehicleCrashDetectionSupported:tripType];
     resolve(supported ? @(YES) : @(NO));
+}
+
+- (BOOL)isThirdPartyLinked {
+    return [[SENTSDK sharedInstance] isThirdPartyLinked];
 }
 
 - (BOOL)isNativeInitializationEnabled {

--- a/ios/RNSentiance.podspec
+++ b/ios/RNSentiance.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RNSentiance"
-  s.version      = "4.0.2"
+  s.version      = "4.4.0"
   s.summary      = "RNSentiance"
   s.description  = <<-DESC
                    RNSentiance
@@ -16,6 +16,5 @@ Pod::Spec.new do |s|
   s.xcconfig     = { 'FRAMEWORK_SEARCH_PATHS' => '${PODS_ROOT}/SENTSDK' }
 
   s.dependency "React"
-  s.dependency "SENTSDK", "5.9.0"
+  s.dependency "SENTSDK", "5.10.0"
 end
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sentiance",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "React Native library for the Sentiance SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes SDK1-1258 by introducing a new method isThirdPartyLinked() which indicates if the SDK has been initialized and third party linking has been completed.

There exists an edge case with the existing native initialization, where the app thinks that third party linking has been completed (either via the custom get/setValue method or the isNativeInitializationEnabled method) but in fact the data is discarded. This PR adds a more robust way to do such native initialization in case user linking is enabled and the ability to recover from such edge cases without requiring the app to be uninstalled.

The README.md still needs to be updated.