### PR TITLE
Moving to 4.4.3 instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.4.2] - 2021-06-09
+## [4.4.3] - 2021-06-10
 ### Changed
 - Upgrade Android SDK to [4.19.1](https://docs.sentiance.com/sdk/changelog/android#4-19-1-9-jun-2021)
 


### PR DESCRIPTION
npm 4.4.2 version did not publish as expected. Therefore, to keep the version history clean, we will delete the 4.4.2 tag and maintain the 4.4.3 instead. 