### PR TITLE
fix: update maven URL to use secure protocol

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
     maven {
-        url "http://repository.sentiance.com"
+        url "https://repository.sentiance.com"
     }
 }
 


### PR DESCRIPTION
With latest RN, the update to gradle 7.2 is required. This version requires explicit consent to allow insecure traffic.